### PR TITLE
Add run-name to enclaver build runs

### DIFF
--- a/.github/workflows/build-eif.yml
+++ b/.github/workflows/build-eif.yml
@@ -22,6 +22,8 @@ on:
     branches:
       - main
 
+run-name: Build Enclaver Docker Image - ${{ github.event.inputs.enclaver_image_name }}
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow for building Enclaver Docker images. The change sets a dynamic run name for workflow executions based on the input `enclaver_image_name`.
