### PR TITLE
Use Image tag instead of Timestamp

### DIFF
--- a/.github/workflows/build-eif.yml
+++ b/.github/workflows/build-eif.yml
@@ -100,7 +100,6 @@ jobs:
           echo "Build complete! Output: $build_output"
           pcr0_raw="0x$(echo "$build_output" | grep -oP '"PCR0": "\K[^"]+')"  
           pcr0_keccak=$(cast keccak $pcr0_raw)
-          echo "PCR0 raw: $pcr0_raw"
           echo "PCR0 keccak hash: $pcr0_keccak"
           echo "ENCLAVE_HASH=${pcr0_keccak}" >> ${GITHUB_ENV}
           docker images
@@ -113,7 +112,7 @@ jobs:
           echo "Adding PCR0 label to image..."
           cat > Dockerfile.labels << EOF
           FROM enclaver-batch-poster
-          LABEL org.opencontainers.image.description="AWS Nitro Enclave batch poster image built with Enclaver - PCR0: ${{ env.ENCLAVE_HASH }}"
+          LABEL org.opencontainers.image.description="AWS Nitro batch poster image built with enclave hash: ${{ env.ENCLAVE_HASH }}"
           LABEL org.opencontainers.image.source="${{ github.server_url }}/${{ github.repository }}"
           LABEL org.opencontainers.image.revision="${{ github.sha }}"
           LABEL org.opencontainers.image.created="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
@@ -124,10 +123,10 @@ jobs:
           
           # Build with labels and tag
           docker build -f Dockerfile.labels -t ghcr.io/espressosystems/aws-nitro-poster:${{ env.NITRO_IMAGE_TAG || 'integration' }} .
-          echo "Tagged with PCR0: ${{ env.ENCLAVE_HASH }}"
+          echo "Tagged with PCR0 HASH: ${{ env.ENCLAVE_HASH }}"
 
       - name: Push Docker
         if: github.event_name != 'pull_request'
         run: |
           docker push ghcr.io/espressosystems/aws-nitro-poster:${{ env.NITRO_IMAGE_TAG || 'integration' }}
-          echo "Pushed image with PCR0: ${{ env.ENCLAVE_HASH }}"
+          echo "Pushed image with PCR0 HASH: ${{ env.ENCLAVE_HASH }}"


### PR DESCRIPTION
This pull request updates the Docker image tagging workflow to use a commit hash from the `nitro_node_image_tag` when available, instead of a simple timestamp.

The resulting value is saved as `FINAL_TAG` for use in subsequent steps.